### PR TITLE
default to 1 battery pack to prevent crash

### DIFF
--- a/nut/lib/check_mk/base/plugins/agent_based/nut.py
+++ b/nut/lib/check_mk/base/plugins/agent_based/nut.py
@@ -190,7 +190,7 @@ def check_nut(item: str, params: Mapping[str, Any], section: Section) -> type_de
 
         # Calculate real voltage
         if metric == 'battery_voltage':
-            upsData[metric] = upsData[metric] * upsData['battery_packs']
+            upsData[metric] = upsData[metric] * upsData.get('battery_packs', 1)
 
         yield from check_levels(
             upsData[metric],


### PR DESCRIPTION
If upsc does not print the value battery.packs the check will crash.
To prevent that, we'll fallback to 1 battery pack.
In my case the battery.voltage is 13.7, so the calculated real voltage should still be accurate.