### PR TITLE
checkmk 2.2 compatibility

### DIFF
--- a/nut/web/plugins/wato/nut.py
+++ b/nut/web/plugins/wato/nut.py
@@ -24,6 +24,7 @@ from cmk.gui.valuespec import (
     ListOf,
     Integer,
     MonitoringState,
+    Float,
 )
 
 from cmk.gui.plugins.wato import (


### PR DESCRIPTION
Checkmk 2.2 needs to import Float from cmk.gui.valuespec explicitly

See
https://forum.checkmk.com/t/error-update-cmk-raw-2-1-0p28-to-2-2-0/38980
https://checkmk.com/werk/15493