### PR TITLE
read configuration file(s) to find monitored UPS's on remote hosts

### DIFF
--- a/nut/agents/plugins/nut
+++ b/nut/agents/plugins/nut
@@ -1,9 +1,25 @@
 #!/bin/bash
 
-if which upsc > /dev/null 2>&1; then
-  echo '<<<nut>>>'
-  for ups in $(upsc -l 2>/dev/null); do
-    echo "==> $ups <=="
-    upsc $ups 2>/dev/null
+which upsc >/dev/null 2>&1 || exit 0
+
+echo '<<<nut>>>'
+
+hosts=`(
+  if which awk >/dev/null 2>&1; then
+    for file in /etc/nut/upsmon.conf; do
+      [ -f $file ] || continue
+      grep "^MONITOR\s" $file
+    done | awk '{if(split($2, parts, "@") >= 2) { print parts[2] } }'
+  fi
+  echo localhost # make sure localhost is on the list
+) | sort -u`
+for host in $hosts; do
+  for ups in $(upsc -l $host 2>/dev/null); do
+    if [ "$host" = "localhost" ]; then
+      echo "==> $ups <=="
+    else
+      echo "==> $ups@$host <=="
+    fi
+    upsc $ups@$host 2>/dev/null
   done
-fi
+done


### PR DESCRIPTION
I have an UPS which is not connected directly to my host but to a remote host and monitored over network. In this case you configure `/etc/nut/upsmon.conf` with something like:
```
MINSUPPLIES 0
MONITOR ups1@otherhost 0 monitoruser password slave
```
You get the list of UPS's on the remote host with `upsc -l otherhost` and the UPS's data with `upsc ups1@otherhost`.

One may expand the list of configuration files by adding to `for file in ...`

The new code gathers a list of hosts from the configuration file(s), loops over these hosts, gets all UPS's from each host and collects their data.